### PR TITLE
fix(docker): pin Python version to 3.11 to avoid httpcore incompatibili

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:latest
+FROM python:3.11-slim
 
 # Copy application source
 COPY ./source ./source

--- a/source/kleinanzeigenbot.py
+++ b/source/kleinanzeigenbot.py
@@ -19,12 +19,15 @@ class KleinanzeigenItem:
         if main is None:
             print("main object of article could not be found")
             return
-        location = main.find("div", {"class": "aditem-main--top--left"}).text
-        price = main.find("p", {"class": "aditem-main--middle--price-shipping--price"}).text
+            
+        location_el = main.find("div", {"class": "aditem-main--top--left"})
+        price_el = main.find("p", {"class": "aditem-main--middle--price-shipping--price"})
+        title_el = main.find("h2", {"class": "text-module-begin"})
+        
+        self.title = title_el.get_text(strip=True) if title_el else "No title"
+        self.location = location_el.get_text(strip=True) if location_el else "location unknown"
+        self.price = price_el.get_text(strip=True) if price_el else "? €"
 
-        self.title = main.find("h2", {"class": "text-module-begin"}).text
-        self.location = location.replace("\n", "") if location is not None else "location unknown"
-        self.price = price.replace("\n", "").replace(" ", "") if price is not None else "? €"
 
     def __eq__(self, __value: object) -> bool:
         return isinstance(__value, KleinanzeigenItem) and self.url == __value.url


### PR DESCRIPTION
…lity

python:latest pulls Python 3.14, which breaks httpcore

To replicate the error use `docker build --no-cache -t python-kleinanzeigen .` to force a rebuild. This gives an `AttributeError: 'typing.Union' object has no attribute '__module__' and no __dict__ for setting new attributes.` in the httpcore module when trying to run it. 
Pinning this to the latest Python version 3.11 compatible with httpcore fixes this issue.